### PR TITLE
Change the default label when anyOf/oneOf is a primitive type.

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -116,7 +116,10 @@ const AnyOneOf: React.FC<SchemaProps> = ({ schema, schemaType }) => {
       </span>
       <SchemaTabs>
         {schema[type]?.map((anyOneSchema: any, index: number) => {
-          const label = anyOneSchema.title || `MOD${index + 1}`;
+          const label =
+            anyOneSchema.title || isPrimitive(anyOneSchema)
+              ? anyOneSchema.type
+              : `MOD${index + 1}`;
           return (
             // @ts-ignore
             <TabItem


### PR DESCRIPTION
## Description

Change the default label of the selector when anyOf/oneOf is a primitive type.

## Motivation and Context

By default, it displays as MOD1, MOD2, which is unclear. It's clearer to display the type name when dealing with primitive types.

## How Has This Been Tested?

Confirmed in the demo tests.
- anyOf with primitives
- oneOf with Primitive Types

## Screenshots (if appropriate)

- anyOf with primitives
![スクリーンショット 2025-05-29 12 30 27](https://github.com/user-attachments/assets/c258af77-a9e5-4085-976c-9c66bde34bcb)

- oneOf with Primitive Types
![スクリーンショット 2025-05-29 12 30 50](https://github.com/user-attachments/assets/a3d1a457-25e3-4529-86cb-700e6f4b270e)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

The default label name of the selector changes when using primitive types with anyOf/oneOf.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
