### PR TITLE
Support schema examples

### DIFF
--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -243,6 +243,76 @@ paths:
                 items:
                   $ref: "#/components/schemas/Book"
 
+  /allof-with-properties-in-array-item:
+    get:
+      tags:
+        - allOf
+      summary: allOf with Properties in Array Item
+      description: |
+        A list of books demonstrating allOf with properties in array item.
+
+        Schema:
+        ```yaml
+        type: array
+        items:
+          $ref: '#/components/schemas/Book'
+        ```
+
+        Schema Components:
+        ```yaml
+        BookBase:
+          type: object
+          required:
+            - id
+            - title
+            - author
+          properties:
+            id:
+              type: integer
+              format: int64
+              description: Unique identifier for the book
+            title:
+              type: string
+              description: The title of the book
+            author:
+              type: string
+              description: The author of the book
+
+        AdditionalBookInfo:
+          type: object
+          properties:
+            publishedDate:
+              type: string
+              format: date
+              description: The date the book was published
+            genre:
+              type: string
+              description: The genre of the book
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags associated with the book
+
+        CategorizedBook:
+          allOf:
+            - $ref: '#/components/schemas/BookBase'
+            - $ref: '#/components/schemas/AdditionalBookInfo'
+          properties:
+            category:
+              type: string
+              description: The category of the book
+        ```
+      responses:
+        "200":
+          description: A list of books
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CategorizedBook"
+
   /allof-nested:
     get:
       tags:
@@ -320,12 +390,15 @@ components:
           type: integer
           format: int64
           description: Unique identifier for the book
+          example: 1234567890
         title:
           type: string
           description: The title of the book
+          example: "The Great Gatsby"
         author:
           type: string
           description: The author of the book
+          example: "F. Scott Fitzgerald"
 
     AdditionalBookInfo:
       type: object
@@ -334,16 +407,29 @@ components:
           type: string
           format: date
           description: The date the book was published
+          example: "2021-01-01"
         genre:
           type: string
           description: The genre of the book
+          example: "Fiction"
         tags:
           type: array
           items:
             type: string
           description: Tags associated with the book
+          example: ["Fiction", "Mystery"]
 
     Book:
       allOf:
         - $ref: "#/components/schemas/BookBase"
         - $ref: "#/components/schemas/AdditionalBookInfo"
+
+    CategorizedBook:
+      allOf:
+        - $ref: "#/components/schemas/BookBase"
+        - $ref: "#/components/schemas/AdditionalBookInfo"
+      properties:
+        category:
+          type: string
+          description: The category of the book
+          example: "Fiction"

--- a/demo/examples/tests/anyOf.yaml
+++ b/demo/examples/tests/anyOf.yaml
@@ -19,6 +19,7 @@ paths:
           - type: string
           - type: integer
           - type: boolean
+          - type: null
         ```
       responses:
         "200":
@@ -30,6 +31,7 @@ paths:
                   - type: string
                   - type: integer
                   - type: boolean
+                  - type: "null"
 
   /anyof-oneof:
     get:

--- a/demo/examples/tests/anyOf.yaml
+++ b/demo/examples/tests/anyOf.yaml
@@ -61,3 +61,63 @@ paths:
                   - type: boolean
                     title: A boolean
                 title: A string or integer, or a boolean
+
+  /anyof-with-properties-in-array-item:
+    get:
+      tags:
+        - anyOf
+      summary: anyOf with Properties in Array Item
+      description: |
+        Schema:
+        ```yaml
+        type: array
+        items:
+          type: object
+          anyOf:
+            - type: object
+              title: Item
+              properties:
+                orderNo:
+                  type: string
+                  example: "123456"
+            - type: object
+              title: Error
+              properties:
+                error:
+                  type: string
+                  example: "Invalid order number"
+          properties:
+            name:
+              type: string
+              example: pencil
+          required:
+            - orderNo
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  anyOf:
+                    - type: object
+                      title: Item
+                      properties:
+                        orderNo:
+                          type: string
+                          example: "123456"
+                    - type: object
+                      title: Error
+                      properties:
+                        error:
+                          type: string
+                          example: "Invalid order number"
+                  properties:
+                    name:
+                      type: string
+                      example: pencil
+                  required:
+                    - orderNo

--- a/demo/examples/tests/oneOf.yaml
+++ b/demo/examples/tests/oneOf.yaml
@@ -22,6 +22,7 @@ paths:
               - type: string
               - type: number
               - type: boolean
+              - type: null
         ```
       responses:
         "200":
@@ -36,6 +37,7 @@ paths:
                       - type: string
                       - type: number
                       - type: boolean
+                      - type: "null"
 
   /oneof-complex-types:
     get:

--- a/demo/examples/tests/oneOf.yaml
+++ b/demo/examples/tests/oneOf.yaml
@@ -262,3 +262,63 @@ paths:
                           requiredPropB:
                             type: number
                         required: ["requiredPropB"]
+
+  /oneof-with-properties-in-array-item:
+    get:
+      tags:
+        - oneOf
+      summary: oneOf with Properties in Array Item
+      description: |
+        Schema:
+        ```yaml
+        type: array
+        items:
+          type: object
+          oneOf:
+            - type: object
+              title: Item
+              properties:
+                orderNo:
+                  type: string
+                  example: "123456"
+            - type: object
+              title: Error
+              properties:
+                error:
+                  type: string
+                  example: "Invalid order number"
+          properties:
+            name:
+              type: string
+              example: pencil
+          required:
+            - orderNo
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  oneOf:
+                    - type: object
+                      title: Item
+                      properties:
+                        orderNo:
+                          type: string
+                          example: "123456"
+                    - type: object
+                      title: Error
+                      properties:
+                        error:
+                          type: string
+                          example: "Invalid order number"
+                  properties:
+                    name:
+                      type: string
+                      example: pencil
+                  required:
+                    - orderNo

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -26,8 +26,8 @@
     "@docusaurus/plugin-google-gtag": "3.7.0",
     "@docusaurus/preset-classic": "3.7.0",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^4.4.0",
-    "docusaurus-theme-openapi-docs": "^4.4.0",
+    "docusaurus-plugin-openapi-docs": "^4.4.1",
+    "docusaurus-theme-openapi-docs": "^4.4.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.4.0",
+  "version": "4.4.1",
   "npmClient": "yarn"
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -18,6 +18,7 @@ interface OASTypeToTypeMap {
   boolean: boolean;
   object: any;
   array: any[];
+  null: string | null;
 }
 
 type Primitives = {
@@ -50,6 +51,9 @@ const primitives: Primitives = {
   },
   object: {},
   array: {},
+  null: {
+    default: () => "null",
+  },
 };
 
 function sampleRequestFromProp(name: string, prop: any, obj: any): any {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -174,11 +174,11 @@ export const sampleRequestFromSchema = (schema: SchemaObject = {}): any => {
 
     if (type === "array") {
       if (Array.isArray(items?.anyOf)) {
-        return items?.anyOf.map((item: any) => sampleRequestFromSchema(item));
+        return processArrayItems(items, "anyOf");
       }
 
       if (Array.isArray(items?.oneOf)) {
-        return items?.oneOf.map((item: any) => sampleRequestFromSchema(item));
+        return processArrayItems(items, "oneOf");
       }
 
       return normalizeArray(sampleRequestFromSchema(items));
@@ -232,4 +232,27 @@ function normalizeArray(arr: any) {
     return arr;
   }
   return [arr];
+}
+
+function processArrayItems(
+  items: SchemaObject,
+  schemaType: "anyOf" | "oneOf"
+): any[] {
+  const itemsArray = items[schemaType] as SchemaObject[];
+  return itemsArray.map((item: SchemaObject) => {
+    // If items has properties, merge them with each item
+    if (items.properties) {
+      const combinedSchema = {
+        ...item,
+        properties: {
+          ...items.properties, // Common properties from parent
+          ...item.properties, // Specific properties from this anyOf/oneOf item
+        },
+      };
+      // Remove anyOf/oneOf to prevent infinite recursion when calling sampleRequestFromSchema
+      delete combinedSchema[schemaType];
+      return sampleRequestFromSchema(combinedSchema);
+    }
+    return sampleRequestFromSchema(item);
+  });
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -18,6 +18,7 @@ interface OASTypeToTypeMap {
   boolean: boolean;
   object: any;
   array: any[];
+  null: string | null;
 }
 
 type Primitives = {
@@ -50,6 +51,9 @@ const primitives: Primitives = {
   },
   object: {},
   array: {},
+  null: {
+    default: () => "null",
+  },
 };
 
 function sampleResponseFromProp(name: string, prop: any, obj: any): any {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -177,11 +177,11 @@ export const sampleResponseFromSchema = (schema: SchemaObject = {}): any => {
 
     if (type === "array") {
       if (Array.isArray(items?.anyOf)) {
-        return items?.anyOf.map((item: any) => sampleResponseFromSchema(item));
+        return processArrayItems(items, "anyOf");
       }
 
       if (Array.isArray(items?.oneOf)) {
-        return items?.oneOf.map((item: any) => sampleResponseFromSchema(item));
+        return processArrayItems(items, "oneOf");
       }
 
       return [sampleResponseFromSchema(items)];
@@ -235,4 +235,27 @@ function normalizeArray(arr: any) {
     return arr;
   }
   return [arr];
+}
+
+function processArrayItems(
+  items: SchemaObject,
+  schemaType: "anyOf" | "oneOf"
+): any[] {
+  const itemsArray = items[schemaType] as SchemaObject[];
+  return itemsArray.map((item: SchemaObject) => {
+    // If items has properties, merge them with each item
+    if (items.properties) {
+      const combinedSchema = {
+        ...item,
+        properties: {
+          ...items.properties, // Common properties from parent
+          ...item.properties, // Specific properties from this anyOf/oneOf item
+        },
+      };
+      // Remove anyOf/oneOf to prevent infinite recursion when calling sampleResponseFromSchema
+      delete combinedSchema[schemaType];
+      return sampleResponseFromSchema(combinedSchema);
+    }
+    return sampleResponseFromSchema(item);
+  });
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import type { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
+import type {
+  JSONSchema4,
+  JSONSchema6,
+  JSONSchema7,
+  JSONSchema7TypeName,
+} from "json-schema";
 
 interface Map<T> {
   [key: string]: T;
@@ -325,6 +330,7 @@ export interface ReferenceObject {
 }
 
 export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+export type SchemaType = JSONSchema7TypeName;
 export type SchemaObject = Omit<
   JSONSchema,
   | "type"
@@ -337,7 +343,7 @@ export type SchemaObject = Omit<
   | "additionalProperties"
 > & {
   // OpenAPI specific overrides
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  type?: SchemaType;
   allOf?: SchemaObject[];
   oneOf?: SchemaObject[];
   anyOf?: SchemaObject[];
@@ -371,7 +377,7 @@ export type SchemaObjectWithRef = Omit<
   | "additionalProperties"
 > & {
   // OpenAPI specific overrides
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  type?: SchemaType;
   allOf?: (SchemaObject | ReferenceObject)[];
   oneOf?: (SchemaObject | ReferenceObject)[];
   anyOf?: (SchemaObject | ReferenceObject)[];

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -36,7 +36,7 @@
     "@types/lodash": "^4.14.176",
     "@types/pako": "^2.0.3",
     "concurrently": "^5.2.0",
-    "docusaurus-plugin-openapi-docs": "^4.4.0",
+    "docusaurus-plugin-openapi-docs": "^4.4.1",
     "docusaurus-plugin-sass": "^0.2.3",
     "eslint-plugin-prettier": "^5.0.1"
   },

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -116,7 +116,10 @@ const AnyOneOf: React.FC<SchemaProps> = ({ schema, schemaType }) => {
       </span>
       <SchemaTabs>
         {schema[type]?.map((anyOneSchema: any, index: number) => {
-          const label = anyOneSchema.title || `MOD${index + 1}`;
+          const label =
+            anyOneSchema.title || isPrimitive(anyOneSchema)
+              ? anyOneSchema.type
+              : `MOD${index + 1}`;
           return (
             // @ts-ignore
             <TabItem

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -21,7 +21,10 @@ import {
   getQualifierMessage,
   getSchemaName,
 } from "docusaurus-plugin-openapi-docs/lib/markdown/schema";
-import { SchemaObject } from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+import {
+  SchemaObject,
+  SchemaType,
+} from "docusaurus-plugin-openapi-docs/lib/openapi/types";
 import isEmpty from "lodash/isEmpty";
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -122,10 +125,7 @@ const AnyOneOf: React.FC<SchemaProps> = ({ schema, schemaType }) => {
               value={`${index}-item-properties`}
             >
               {/* Handle primitive types directly */}
-              {(["string", "number", "integer", "boolean"].includes(
-                anyOneSchema.type
-              ) ||
-                anyOneSchema.const) && (
+              {(isPrimitive(anyOneSchema) || anyOneSchema.const) && (
                 <SchemaItem
                   collapsible={false}
                   name={undefined}
@@ -938,3 +938,17 @@ const SchemaNode: React.FC<SchemaProps> = ({ schema, schemaType }) => {
 };
 
 export default SchemaNode;
+
+type PrimitiveSchemaType = Exclude<SchemaType, "object" | "array">;
+
+const PRIMITIVE_TYPES: Record<PrimitiveSchemaType, true> = {
+  string: true,
+  number: true,
+  integer: true,
+  boolean: true,
+  null: true,
+} as const;
+
+const isPrimitive = (schema: SchemaObject) => {
+  return PRIMITIVE_TYPES[schema.type as PrimitiveSchemaType];
+};

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -8,6 +8,8 @@
 import React, { ReactNode } from "react";
 
 import Markdown from "@theme/Markdown";
+import SchemaTabs from "@theme/SchemaTabs";
+import TabItem from "@theme/TabItem";
 import clsx from "clsx";
 
 import { guard } from "../../markdown/utils";
@@ -63,6 +65,7 @@ export default function SchemaItem(props: Props) {
   let schemaDescription;
   let defaultValue: string | undefined;
   let example: string | undefined;
+  let examples: any[] | undefined;
   let nullable;
   let enumDescriptions: [string, string][] = [];
   let constValue: string | undefined;
@@ -73,6 +76,7 @@ export default function SchemaItem(props: Props) {
     enumDescriptions = transformEnumDescriptions(schema["x-enumDescriptions"]);
     defaultValue = schema.default;
     example = schema.example;
+    examples = schema.examples;
     nullable =
       schema.nullable ||
       (Array.isArray(schema.type) && schema.type.includes("null")); // support JSON Schema nullable
@@ -163,6 +167,46 @@ export default function SchemaItem(props: Props) {
     return undefined;
   }
 
+  function renderExamplesList() {
+    if (examples && Array.isArray(examples) && examples.length > 0) {
+      if (examples.length === 1) {
+        const value = examples[0];
+        if (typeof value === "string") {
+          return (
+            <div>
+              <strong>Example: </strong>
+              <span>
+                <code>{value}</code>
+              </span>
+            </div>
+          );
+        }
+        return (
+          <div>
+            <strong>Example: </strong>
+            <span>
+              <code>{JSON.stringify(value)}</code>
+            </span>
+          </div>
+        );
+      }
+      return (
+        <>
+          <strong>Examples:</strong>
+          <SchemaTabs>
+            {examples.map((ex, i) => (
+              // @ts-ignore
+              <TabItem key={i} value={String(i)} label={`Example ${i + 1}`}>
+                <code>{typeof ex === "string" ? ex : JSON.stringify(ex)}</code>
+              </TabItem>
+            ))}
+          </SchemaTabs>
+        </>
+      );
+    }
+    return undefined;
+  }
+
   function renderConstValue() {
     if (constValue !== undefined) {
       if (typeof constValue === "string") {
@@ -213,6 +257,7 @@ export default function SchemaItem(props: Props) {
       {renderConstValue()}
       {renderDefaultValue()}
       {renderExample()}
+      {renderExamplesList()}
       {collapsibleSchemaContent ?? collapsibleSchemaContent}
     </div>
   );


### PR DESCRIPTION
## Summary
- render array-style SchemaObject examples in SchemaItem

## Testing
- `yarn lint packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx` *(fails: cannot download yarn)*

------
https://chatgpt.com/codex/tasks/task_e_6842596453e0832ebae0394973eddc1a